### PR TITLE
Add callback option to api.info().

### DIFF
--- a/lib/drivers/veres.js
+++ b/lib/drivers/veres.js
@@ -598,7 +598,7 @@ api.info = async options => {
 
   // check for optional callback param (used to return the results directly
   //  instead of displaying them)
-  const callback = options.callback;
+  const {callback} = options;
 
   // info from requested locations
   const locations = [];
@@ -641,7 +641,7 @@ api.info = async options => {
     // omit "not found" info if requested
     if(!options.retryShowFound || (options.retryShowFound && result.found)) {
       if(callback) {
-        callback(null, result, options);
+        callback(null, result);
       } else {
         _info(result, options);
       }
@@ -651,7 +651,7 @@ api.info = async options => {
       (result.timeMs >= options.retryTimeoutMs ||
         result.retries >= options.retryMax)) {
       if(callback) {
-        callback(null, result, options);
+        callback(null, result);
       } else {
         _info(result, options);
       }

--- a/lib/drivers/veres.js
+++ b/lib/drivers/veres.js
@@ -596,6 +596,10 @@ function _delay(delay) {
 api.info = async options => {
   _verbose(options, 'DID:', options.did);
 
+  // check for optional callback param (used to return the results directly
+  //  instead of displaying them)
+  const callback = options.callback;
+
   // info from requested locations
   const locations = [];
 
@@ -636,13 +640,21 @@ api.info = async options => {
   async function looper(result) {
     // omit "not found" info if requested
     if(!options.retryShowFound || (options.retryShowFound && result.found)) {
-      _info(result, options);
+      if(callback) {
+        callback(null, result, options);
+      } else {
+        _info(result, options);
+      }
     }
     // output final failure if timeout or max retries
     if(!result.found && options.retry &&
       (result.timeMs >= options.retryTimeoutMs ||
         result.retries >= options.retryMax)) {
-      _info(result, options);
+      if(callback) {
+        callback(null, result, options);
+      } else {
+        _info(result, options);
+      }
       return;
     }
     // retry if needed


### PR DESCRIPTION
I'd like to be able to use `did-client` in the did-whisper lib, to fetch locally stored DID Documents (to get their private keys for encryption). This PR enables a downstream library to use api.info() directly, like so:

```js
const { veres } = require('did-client')

const options = {
  did: 'did:v1:test:nym:...',
  location: 'local',
  callback: (error, result) => { console.log('Retrieved DID Doc:', result) } 
}
veres.info(options)
```

(The current behavior is to console.log() the results, which makes it not easily accessible to the caller code).