### PR TITLE
Rename -l/ledger cli param to -t/type.

### DIFF
--- a/did
+++ b/did
@@ -2,7 +2,7 @@
 /**
  * A Decentralized Identifier client for managing DIDs.
  *
- * Copyright (c) 2017 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2017-2019 Digital Bazaar, Inc. All rights reserved.
  */
 const drivers = require('./lib');
 const yargs = require('yargs');
@@ -14,16 +14,13 @@ const {homepage} = require(join(__dirname, 'package.json'));
 const tls = require('tls');
 tls.DEFAULT_ECDH_CURVE = 'auto';
 
-function _setupLedgerCommand(yargs) {
+function _setupTypeCommand(yargs) {
   return yargs
-    .option('ledger', {
-      alias: 'l',
-      describe: 'DID ledger to use',
+    .option('type', {
+      alias: 't',
+      describe: 'DID type (method) to use',
       choices: [
-        'btcr',
-        'consensys',
-        'sovrin',
-        'uport',
+        'key',
         'veres'
       ],
       default: 'veres'
@@ -44,7 +41,7 @@ function _setupRemoteCommand(yargs) {
     })
     .option('hostname', {
       alias: 'H',
-      describe: 'Ledger hostname (overrides mode/ledger)',
+      describe: 'Ledger hostname (overrides mode/type)',
       type: 'string',
       nargs: 1
     })
@@ -132,7 +129,7 @@ function _setupExamples(yargs, cmd) {
     'Generate a DID with a passphrase');
   example(
     ['generate'],
-    '$0 generate -m dev -t rsa -r',
+    '$0 generate -m dev -k rsa -r',
     'Generate a DID and register on development ledger');
   example(
     ['main', 'generate'],
@@ -140,7 +137,7 @@ function _setupExamples(yargs, cmd) {
     'Generate a local DID with private notes');
   example(
     ['main', 'generate'],
-    '$0 generate -t rsa -r',
+    '$0 generate -k rsa -r',
     'Generate a RSA DID and register on ledger');
   example(
     ['generate'],
@@ -253,7 +250,7 @@ function _setupExamples(yargs, cmd) {
   example(
     ['main', 'service-add'],
     '$0 service-add <did> -f myservice -e https://example.com ' +
-    '-t urn:myservicetype',
+    '-s urn:myservicetype',
     'Add a service descriptor to a DID');
 }
 
@@ -267,7 +264,7 @@ yargs
   .env('DID_CLIENT')
 
   .command(['list', 'ls'],
-    'List local DIDs',
+    'List pending and registered DIDs',
     yargs => {
       _setupExamples(yargs, 'list');
     },
@@ -284,15 +281,15 @@ yargs
   .command('generate',
     'Generate a DID',
     yargs => {
-      _setupLedgerCommand(yargs);
+      _setupTypeCommand(yargs);
       _setupRemoteCommand(yargs);
       _setupRegisterCommand(yargs);
       _setupAcceleratorCommand(yargs);
       _setupNotesCommand(yargs);
       _setupExamples(yargs, 'generate');
       yargs
-        .option('type', {
-          alias: 't',
+        .option('keytype', {
+          alias: 'k',
           describe: 'Key type',
           choices: [
             'ed25519',
@@ -322,7 +319,7 @@ yargs
   .command('register [did]',
     'Register a DID on a ledger',
     yargs => {
-      _setupLedgerCommand(yargs);
+      _setupTypeCommand(yargs);
       _setupDidCommand(yargs);
       _setupRemoteCommand(yargs);
       _setupAcceleratorCommand(yargs);
@@ -334,7 +331,7 @@ yargs
   .command('receive <did>',
     'Receive DID from ledger',
     yargs => {
-      _setupLedgerCommand(yargs);
+      _setupTypeCommand(yargs);
       _setupDidCommand(yargs);
       _setupRemoteCommand(yargs);
       _setupExamples(yargs, 'receive');
@@ -355,7 +352,7 @@ yargs
   .command(['info <did>', 'i', 'get'],
     'Show DID information',
     yargs => {
-      _setupLedgerCommand(yargs);
+      _setupTypeCommand(yargs);
       _setupDidCommand(yargs);
       _setupRemoteCommand(yargs);
       _setupExamples(yargs, 'info');
@@ -429,7 +426,7 @@ yargs
   .command(['notes [did]', 'n'],
     'Manage DID private notes',
     yargs => {
-      _setupLedgerCommand(yargs);
+      _setupTypeCommand(yargs);
       _setupDidCommand(yargs);
       _setupRemoteCommand(yargs);
       _setupExamples(yargs, 'notes');
@@ -490,7 +487,7 @@ yargs
   .command('ed25519-key-add <did>',
     'Add an ed25519 verification method to a DID',
     yargs => {
-      _setupLedgerCommand(yargs);
+      _setupTypeCommand(yargs);
       _setupDidCommand(yargs);
       _setupRemoteCommand(yargs);
       _setupAcceleratorCommand(yargs);
@@ -525,7 +522,7 @@ yargs
   .command('authn-remove <did> <key>',
     'Remove an existing DID authentication key',
     yargs => {
-      _setupLedgerCommand(yargs);
+      _setupTypeCommand(yargs);
       _setupDidCommand(yargs);
       _setupRemoteCommand(yargs);
       _setupAcceleratorCommand(yargs);
@@ -542,7 +539,7 @@ yargs
   .command('authn-rotate <did> <old-key>',
     'Rotate an existing DID authentication key',
     yargs => {
-      _setupLedgerCommand(yargs);
+      _setupTypeCommand(yargs);
       _setupDidCommand(yargs);
       _setupRemoteCommand(yargs);
       _setupAcceleratorCommand(yargs);
@@ -560,7 +557,7 @@ yargs
   .command('ocap-add <did> <invoker>',
     'Add an object capability DID Document',
     yargs => {
-      _setupLedgerCommand(yargs);
+      _setupTypeCommand(yargs);
       _setupDidCommand(yargs);
       _setupOcapCommand(yargs);
       _setupRegisterCommand(yargs);
@@ -573,7 +570,7 @@ yargs
   .command('ocap-revoke <did>',
     'Remove an object capability DID Document',
     yargs => {
-      _setupLedgerCommand(yargs);
+      _setupTypeCommand(yargs);
       _setupDidCommand(yargs);
       //_setupOcapCommand(yargs);
       _setupRegisterCommand(yargs);
@@ -585,7 +582,7 @@ yargs
   .command('service-add <did>',
     'Add a service descriptor a DID',
     yargs => {
-      _setupLedgerCommand(yargs);
+      _setupTypeCommand(yargs);
       _setupDidCommand(yargs);
       _setupRemoteCommand(yargs);
       // _setupAcceleratorCommand(yargs);
@@ -604,8 +601,8 @@ yargs
           type: 'string',
           nargs: 1,
         })
-        .option('type', {
-          alias: 't',
+        .option('servicetype', {
+          alias: 's',
           describe: 'Service type URI',
           type: 'string',
           nargs: 1,
@@ -650,9 +647,9 @@ process.on('unhandledRejection', error => {
 
 function _runLedgerCommand(command, argv) {
   try {
-    const driver = drivers[argv.ledger];
+    const driver = drivers[argv.type];
     if(!driver) {
-      throw new Error(`"${argv.ledger}" ledger not supported`);
+      throw new Error(`"${argv.type}" DID type not supported`);
     }
     if(argv.verbose >= 1) {
       console.log(

--- a/lib/drivers/veres/index.js
+++ b/lib/drivers/veres/index.js
@@ -23,16 +23,17 @@ const _keyTypes = {
 /**
  * @param {object} options
  *
- * Ledger:
- * @param {string} [options.ledger='veres'] - Which ledger.
- * @param {string} [options.mode='test'] - Ledger mode (test/live/dev).
- * @param {string} [options.hostname] - Ledger node hostname override.
+ * DID Type / method:
+ * @param {string} [options.type='veres'] - DID type / method.
+ * @param {string} [options.mode='test'] - Ledger mode (test/live/dev), if
+ *   applicable.
+ * @param {string} [options.hostname] - Ledger node hostname override
  * @param {string} [options.auth] - Authorization DID.
  * @param {string} [options.accelerator] - Accelerator hostname[:port].
  * @param {boolean} [options.register=false]
  *
  * Key:
- * @param {string} [options.type='ed25519'] - Key type.
+ * @param {string} [options.keytype='ed25519'] - Key type.
  * @param {string} [options.passphrase]
  *
  * Descriptive metadata (not stored in DID itself):
@@ -44,14 +45,14 @@ const _keyTypes = {
  */
 api.generate = async options => {
   // TODO: Support custom httpsAgent?
-  const {ledger, mode, hostname, passphrase} = options;
-  if(ledger !== 'veres') {
-    throw new Error(`Ledger ${ledger} not supported.`);
+  const {type, mode, hostname, passphrase} = options;
+  if(type !== 'veres') {
+    throw new Error(`DID type ${type} is not supported.`);
   }
   const httpsAgent = new https.Agent({rejectUnauthorized: mode !== 'dev'});
   const veresDriver = v1.driver({mode, hostname, httpsAgent});
 
-  const keyType = _keyTypes[options.type];
+  const keyType = _keyTypes[options.keytype];
 
   // check known key types
   if(!keyType) {
@@ -85,8 +86,8 @@ api.generate = async options => {
   // Save metadata / notes
   await metaStore().put(did, notes);
 
-  const pendingDids = didStore({ledger, mode, status: 'pending'});
-  const registeredDids = didStore({ledger, mode, status: 'registered'});
+  const pendingDids = didStore({type, mode, status: 'pending'});
+  const registeredDids = didStore({type, mode, status: 'registered'});
 
   await pendingDids.put(did, didDocument);
 
@@ -107,7 +108,7 @@ api.generate = async options => {
  * @param {string} options.did - DID to register.
  *
  * Ledger:
- * @param {string} [options.ledger='veres'] - Which ledger.
+ * @param {string} [options.type='veres'] - DID type / method.
  * @param {string} [options.mode='test'] - Ledger mode (test/live/dev).
  * @param {string} [options.hostname] - Ledger node hostname override.
  * @param {string} [options.auth] - Authorization DID.
@@ -115,21 +116,22 @@ api.generate = async options => {
  * @returns {Promise}
  */
 api.register = async options => {
-  const {did, ledger, mode, hostname} = options;
-  if(ledger !== 'veres') {
-    throw new Error(`Ledger ${ledger} not supported.`);
+  const {did, type, mode, hostname} = options;
+  if(type !== 'veres') {
+    throw new Error(`DID type ${type} is not supported.`);
   }
   if(!did) {
     throw new Error('Cannot register - missing DID.');
   }
 
-  const pendingDids = didStore({ledger, mode, status: 'pending'});
-  const registeredDids = didStore({ledger, mode, status: 'registered'});
+  const pendingDids = didStore({type, mode, status: 'pending'});
+  const registeredDids = didStore({type, mode, status: 'registered'});
 
   const httpsAgent = new https.Agent({rejectUnauthorized: mode !== 'dev'});
   const veresDriver = v1.driver({mode, hostname, httpsAgent});
 
   logger._debug(options, 'registering DID', did);
+
   const doc = await pendingDids.get(did);
   if(!doc) {
     throw new Error(`DID ${did} not found.`);
@@ -481,9 +483,12 @@ api['ocap-revoke'] = async options => {
   throw new Error('ocap-add not implemented');
 };
 
-/* eslint-disable-next-line no-unused-vars */
-api['list'] = async options => {
-  throw new Error('list not implemented');
+/**
+ * @param {string} [type='veres'] - Which DID method.
+ * @param {string} [mode='test'] - Ledger mode (test/live/dev).
+ * @returns {Promise}
+ */
+api['list'] = async ({type, mode}) => {
 };
 
 /* eslint-disable-next-line no-unused-vars */

--- a/lib/drivers/veres/logger.js
+++ b/lib/drivers/veres/logger.js
@@ -10,7 +10,7 @@ module.exports = api;
 
 api.__log = (options, f, msg, ...rest) => {
   f(
-    `[${chalk.bold('Veres One')}][${chalk.bold(options.mode)}] ${msg}`,
+    `[${chalk.bold('Veres One')}][${chalk.bold(options.mode)} mode] ${msg}`,
     ...rest);
 };
 

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -55,14 +55,14 @@ const os = require('os');
  * // result -> null  (does not throw an error)
  * ```
  *
- * @param [options.ledger] {string} Ledger id, for example, 'veres'
+ * @param [options.type] {string} DID method / type, for example, 'veres'
  * @param [options.mode] {string} 'test'/'live'
  */
 function didStore(options) {
-  const {ledger, mode} = options;
-  const status = options.status || 'pending';
+  const {type, mode} = options;
+  const status = options.status || '';
   const dir = options.dir ||
-    path.join(os.homedir(), '.dids', `${ledger}-${mode}`, status);
+    path.join(os.homedir(), '.dids', `${type}-${mode}`, status);
   const extension = '.json';
   return Store.using('files', {dir, extension, ...options});
 }


### PR DESCRIPTION
Renaming the `-l` / `--ledger` parameter to `-t` / `--type`. We considered using `method` instead, but that might be too esoteric to devs. Ledger doesn't quite match (not all did methods are on a ledger, and many different incompatible did methods use the same ledger (ie Ethereum)), so we settled on `type`.