### PR TITLE
Update did-veres-one dep to latest.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,19 +24,19 @@
   },
   "homepage": "https://github.com/digitalbazaar/did-cli",
   "dependencies": {
-    "chalk": "^3.0.0",
+    "chalk": "^4.0.0",
     "crypto-ld": "^3.7.0",
-    "did-veres-one": "^11.0.1",
-    "flex-docstore": "^0.1.0",
+    "did-veres-one": "^12.0.0",
+    "flex-docstore": "^0.1.2",
     "glob": "^7.1.6",
-    "jsonld": "^1.8.1",
-    "yargs": "^15.0.2"
+    "jsonld": "^3.0.1",
+    "yargs": "^15.3.1"
   },
   "engines": {
     "node": ">=8.6.0"
   },
   "devDependencies": {
-    "eslint": "^6.7.0",
-    "eslint-config-digitalbazaar": "^2.0.1"
+    "eslint": "^6.8.0",
+    "eslint-config-digitalbazaar": "^2.3.0"
   }
 }


### PR DESCRIPTION
Update dependencies to latest. Includes the new `get()`/404 behavior in did-veres-one.