### PR TITLE
Implement basic key create command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,6 @@ SECRET_KEY_SEED=z1Ajrg3wpDYiKS1EKAZKDd8qwR5mG3wKvh6gYi5YEz9T89P ./did key create
   },
   "secretKeySeed": "z1Ajrg3wpDYiKS1EKAZKDd8qwR5mG3wKvh6gYi5YEz9T89P"
 }
-
 ```
 
 ## Contribute

--- a/README.md
+++ b/README.md
@@ -47,6 +47,42 @@ Help is available with the `--help/-h` command line option:
 ./did COMMAND -h
 ```
 
+### Key Pairs
+
+#### Generating a key pair
+
+To generate a new public/private key pair:
+
+```
+ ./did key create
+{
+  "keyPair": {
+    "type": "Ed25519VerificationKey2020",
+    "@context": "https://w3id.org/security/suites/ed25519-2020/v1",
+    "publicKeyMultibase": "z6MkmDMjfkjs9XPCN1LfoQQRHz1mJ8PEdiVYC66XKhj3wGyB",
+    "privateKeyMultibase": "zrv3wmB9AVHitGUTEf9MVMB6afscXMmzGY7hwuYL5gZZdspFr2DDrTA97qzZS6T1MsJM4mTKVWQWkjY5asc8FBppKt9"
+  },
+  "secretKeySeed": "z1AhV1bADy7RepJ64mvH7Kk7htFNGc7EA1WA5nGzLSTWc6o"
+}
+```
+
+If you have a secret key seed already, set the `SECRET_KEY_SEED` env variable,
+and the key pair will be deterministically generated from it:
+
+```
+SECRET_KEY_SEED=z1Ajrg3wpDYiKS1EKAZKDd8qwR5mG3wKvh6gYi5YEz9T89P ./did key create
+{
+  "keyPair": {
+    "type": "Ed25519VerificationKey2020",
+    "@context": "https://w3id.org/security/suites/ed25519-2020/v1",
+    "publicKeyMultibase": "z6Mkf9XLrKqb6kch96MU61aciKrnQwQmBnFw9MGpyqHor81V",
+    "privateKeyMultibase": "zrv4ef4DVKCmCzy9733LKCnghDP1mytArm7Jddtnq54M1sVThc95bxJ2H4TiuWXRChjGHWtocqKciPrnqUBAatLUKqq"
+  },
+  "secretKeySeed": "z1Ajrg3wpDYiKS1EKAZKDd8qwR5mG3wKvh6gYi5YEz9T89P"
+}
+
+```
+
 ## Contribute
 
 See [the contribute file](https://github.com/digitalbazaar/bedrock/blob/master/CONTRIBUTING.md)!

--- a/did
+++ b/did
@@ -19,7 +19,7 @@ async function main() {
     })
     .demandCommand(1, 'Please specify a command to execute.');
 
-  // didCli.did.command(cli);
+  didCli.key.command(cli);
 
   cli.argv;
 }

--- a/lib/key/cli.js
+++ b/lib/key/cli.js
@@ -9,7 +9,7 @@ function keyCommand(yargs) {
   return yargs.command('key <action>', 'Generate and manage key pairs.', {
     handler: _handler,
     builder: _yargs => {
-      _setupFormatOption;
+      _setupFormatOption(yargs);
       return _yargs
         .positional('action', {
           describe: 'Action to perform.',

--- a/lib/key/cli.js
+++ b/lib/key/cli.js
@@ -1,0 +1,35 @@
+/*!
+ * Copyright (c) 2021 Digital Bazaar, Inc. All rights reserved.
+ */
+import * as key from '.';
+import {_displayOutput} from '../displayOutput.js';
+import {_setupFormatOption} from '../options.js';
+
+function keyCommand(yargs) {
+  return yargs.command('key <action>', 'Generate and manage key pairs.', {
+    handler: _handler,
+    builder: _yargs => {
+      _setupFormatOption;
+      return _yargs
+        .positional('action', {
+          describe: 'Action to perform.',
+          choices: ['create'],
+          default: 'create'
+        });
+    }
+  });
+}
+
+async function _handler(args) {
+  const secretKeySeed = process.env.SECRET_KEY_SEED;
+  switch(args.action) {
+    case 'create':
+      const res = await key.create({secretKeySeed, ...args});
+      _displayOutput(res, args);
+      break;
+    default:
+      console.log(`Error: '${args._} ${args.action}' command not supported.`);
+      process.exit(1);
+  }
+}
+export {keyCommand as command};

--- a/lib/key/index.js
+++ b/lib/key/index.js
@@ -1,0 +1,44 @@
+/*!
+ * Copyright (c) 2021 Digital Bazaar, Inc. All rights reserved.
+ */
+import {Ed25519VerificationKey2020} from
+  '@digitalbazaar/ed25519-verification-key-2020';
+import {generateSecretKeySeed, decodeSecretKeySeed} from 'bnid';
+
+/**
+ * Generates a key pair. If no seed is given, a random one is generated.
+ *
+ * @param {object} options - Options hashmap.
+ * @param {string} options.secretKeySeed - 32 byte random seed value, multihash
+ *   identified, and multibase-encoded.
+ *
+ * @returns {Promise<{keyPair: object, secretKeySeed: string}>} - Resolves
+ *   with a key pair, and optionally a text-encoded secret seed (if none was
+ *   provided).
+ */
+export async function create({secretKeySeed}) {
+  let keyPair;
+
+  if(!secretKeySeed) {
+    secretKeySeed = await generateSecretKeySeed();
+  }
+
+  try {
+    const seedBytes = decodeSecretKeySeed({secretKeySeed});
+    keyPair = await Ed25519VerificationKey2020.generate({seed: seedBytes});
+  } catch(e) {
+    if(e.message === 'Decoded identifier size too large.') {
+      console.log('Secret key seed must be a 32 byte random value, ' +
+        'multihash identified and multibase encoded.');
+    } else {
+      console.error(e);
+    }
+    process.exit(1);
+  }
+  return {
+    keyPair: keyPair.export({
+      publicKey: true, privateKey: true, includeContext: true
+    }),
+    secretKeySeed
+  };
+}

--- a/lib/options.js
+++ b/lib/options.js
@@ -1,0 +1,16 @@
+/*!
+ * Copyright (c) 2021 Digital Bazaar, Inc. All rights reserved.
+ */
+export function _setupFormatOption(yargs) {
+  return yargs
+    .option('format', {
+      type: 'string',
+      describe: 'Output format',
+      choices: [
+        'json-compact',
+        'json'
+      ],
+      default: 'json',
+      alias: 'f'
+    });
+}

--- a/main.js
+++ b/main.js
@@ -1,3 +1,9 @@
 /*!
  * Copyright (c) 2021 Digital Bazaar, Inc. All rights reserved.
  */
+
+import * as key from './lib/key/cli.js';
+
+export {
+  key
+};

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
   },
   "homepage": "https://github.com/digitalbazaar/did-cli",
   "dependencies": {
+    "@digitalbazaar/ed25519-verification-key-2020": "^3.2.0",
+    "bnid": "^2.1.0",
     "chalk": "^4.0.0",
     "esm": "^3.2.22",
     "flex-docstore": "^0.1.2",


### PR DESCRIPTION
This is the first in a series that re-builds `did-cli` based on Digital Bazaar's latest CLI template.

This PR adds a `./did key create` command that generates random new key pairs, or deterministically derives them from a secret key seed.